### PR TITLE
Added the CoriolisSrc class (#47)

### DIFF
--- a/include/CoriolisSrc.h
+++ b/include/CoriolisSrc.h
@@ -1,0 +1,45 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef CoriolisSrc_h
+#define CoriolisSrc_h
+
+#include <vector>
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+
+class CoriolisSrc {
+public:
+
+  CoriolisSrc(Realm &realm);
+
+  virtual ~CoriolisSrc() {}
+
+  void cross_product(std::vector<double> u, std::vector<double> v, std::vector<double> cross);
+
+  int nDim_;
+  double earthAngularVelocity_;
+  double latitude_;
+  double sinphi_;
+  double cosphi_;
+  double corfac_;
+  double Jxy_, Jxz_, Jyz_;
+  double pi_;
+  std::vector<double> eastVector_;
+  std::vector<double> northVector_;
+  std::vector<double> upVector_;
+
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/MomentumCoriolisSrcNodeSuppAlg.h
+++ b/include/MomentumCoriolisSrcNodeSuppAlg.h
@@ -11,6 +11,7 @@
 
 #include <SupplementalAlgorithm.h>
 #include <FieldTypeDef.h>
+#include <CoriolisSrc.h>
 
 #include <stk_mesh/base/Entity.hpp>
 
@@ -35,22 +36,10 @@ public:
     double *rhs,
     stk::mesh::Entity node);
 
-  void cross_product(std::vector<double> u, std::vector<double> v, std::vector<double> cross);
-
+  CoriolisSrc cor_;
   ScalarFieldType *densityNp1_;
   ScalarFieldType *dualNodalVolume_;
   VectorFieldType *velocityNp1_;
-  int nDim_;
-  double earthAngularVelocity_;
-  double latitude_;
-  double sinphi_;
-  double cosphi_;
-  double corfac_;
-  double Jxy_, Jxz_, Jyz_;
-  double pi_;
-  std::vector<double> eastVector_;
-  std::vector<double> northVector_;
-  std::vector<double> upVector_;
 
 };
 

--- a/src/CoriolisSrc.C
+++ b/src/CoriolisSrc.C
@@ -1,0 +1,82 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include <CoriolisSrc.h>
+#include <Realm.h>
+#include <SolutionOptions.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/MetaData.hpp>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// CoriolisSrc
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+CoriolisSrc::CoriolisSrc(Realm &realm) {
+
+  pi_ = std::acos(-1.0);
+
+  stk::mesh::MetaData & meta_data = realm.meta_data();
+
+  // extract user parameters from solution options
+  earthAngularVelocity_ = realm.solutionOptions_->earthAngularVelocity_;
+  latitude_ = realm.solutionOptions_->latitude_ * pi_ / 180.0;
+  nDim_ = meta_data.spatial_dimension();
+  if (nDim_ != 3) 
+    throw std::runtime_error("CoriolisSrc: nDim_ != 3");
+  eastVector_.resize(nDim_);
+  northVector_.resize(nDim_);
+  upVector_.resize(nDim_);
+  eastVector_ = realm.solutionOptions_->eastVector_;
+  northVector_ = realm.solutionOptions_->northVector_;
+
+  // normalize the east and north vectors
+  double magE = std::sqrt(eastVector_[0]*eastVector_[0]+eastVector_[1]*eastVector_[1]+eastVector_[2]*eastVector_[2]);
+  double magN = std::sqrt(northVector_[0]*northVector_[0]+northVector_[1]*northVector_[1]+northVector_[2]*northVector_[2]);
+  for (int i=0; i<nDim_; ++i) {
+    eastVector_[i] /= magE;
+    northVector_[i] /= magN;
+  }
+
+  // calculate the 'up' unit vector
+  cross_product(eastVector_, northVector_, upVector_);
+
+  // some factors that do not change
+  sinphi_ = std::sin(latitude_);
+  cosphi_ = std::cos(latitude_);
+  corfac_ = 2.0*earthAngularVelocity_;
+
+  // Jacobian entries
+  Jxy_ = corfac_ * (eastVector_[0]*northVector_[1]-northVector_[0]*eastVector_[1])*sinphi_
+                 + (upVector_[0]*eastVector_[1]-eastVector_[0]*upVector_[1])*cosphi_;
+  Jxz_ = corfac_ * (eastVector_[0]*northVector_[2]-northVector_[0]*eastVector_[2])*sinphi_
+                 + (upVector_[0]*eastVector_[2]-eastVector_[0]*upVector_[2])*cosphi_;
+  Jyz_ = corfac_ * (eastVector_[1]*northVector_[2]-northVector_[1]*eastVector_[2])*sinphi_
+                 + (upVector_[1]*eastVector_[2]-eastVector_[1]*upVector_[2])*cosphi_;
+}
+
+//--------------------------------------------------------------------------
+//-------- cross_product ----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+CoriolisSrc::cross_product(
+  std::vector<double> u, std::vector<double> v, std::vector<double> cross)
+{
+  cross[0] =   u[1]*v[2] - u[2]*v[1];
+  cross[1] = -(u[0]*v[2] - u[2]*v[0]);
+  cross[2] =   u[0]*v[1] - u[1]*v[0];
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/MomentumCoriolisSrcNodeSuppAlg.C
+++ b/src/MomentumCoriolisSrcNodeSuppAlg.C
@@ -7,6 +7,7 @@
 
 
 #include <MomentumCoriolisSrcNodeSuppAlg.h>
+#include <CoriolisSrc.h>
 #include <FieldTypeDef.h>
 #include <Realm.h>
 #include <SolutionOptions.h>
@@ -35,57 +36,16 @@ MomentumCoriolisSrcNodeSuppAlg::MomentumCoriolisSrcNodeSuppAlg(
     densityNp1_(NULL),
     velocityNp1_(NULL),
     dualNodalVolume_(NULL),
-    nDim_(1),
-    earthAngularVelocity_(0.0),
-    latitude_(0.0)
+    cor_(realm)
 {
-
-  pi_ = std::acos(-1.0);
-
+  
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   VectorFieldType *velocity = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  // Do we need density for the compressible form of the Coriolis term?
   ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
   dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-
-  // extract user parameters from solution options
-  earthAngularVelocity_ = realm_.solutionOptions_->earthAngularVelocity_;
-  latitude_ = realm_.solutionOptions_->latitude_ * pi_ / 180.0;
-  nDim_ = meta_data.spatial_dimension();
-  if (nDim_ != 3) 
-    throw std::runtime_error("MomentumCoriolisSrcNodeSuppAlg: nDim != 3");
-  eastVector_.resize(nDim_);
-  northVector_.resize(nDim_);
-  upVector_.resize(nDim_);
-  eastVector_ = realm_.solutionOptions_->eastVector_;
-  northVector_ = realm_.solutionOptions_->northVector_;
-
-  // normalize the east and north vectors
-  double magE = std::sqrt(eastVector_[0]*eastVector_[0]+eastVector_[1]*eastVector_[1]+eastVector_[2]*eastVector_[2]);
-  double magN = std::sqrt(northVector_[0]*northVector_[0]+northVector_[1]*northVector_[1]+northVector_[2]*northVector_[2]);
-  for (int i=0; i<nDim_; ++i) {
-    eastVector_[i] /= magE;
-    northVector_[i] /= magN;
-  }
-
-  // calculate the 'up' unit vector
-  cross_product(eastVector_, northVector_, upVector_);
-
-  // some factors that do not change
-  sinphi_ = std::sin(latitude_);
-  cosphi_ = std::cos(latitude_);
-  corfac_ = 2.0*earthAngularVelocity_;
-
-  // Jacobian entries
-  Jxy_ = corfac_ * (eastVector_[0]*northVector_[1]-northVector_[0]*eastVector_[1])*sinphi_
-                 + (upVector_[0]*eastVector_[1]-eastVector_[0]*upVector_[1])*cosphi_;
-  Jxz_ = corfac_ * (eastVector_[0]*northVector_[2]-northVector_[0]*eastVector_[2])*sinphi_
-                 + (upVector_[0]*eastVector_[2]-eastVector_[0]*upVector_[2])*cosphi_;
-  Jyz_ = corfac_ * (eastVector_[1]*northVector_[2]-northVector_[1]*eastVector_[2])*sinphi_
-                 + (upVector_[1]*eastVector_[2]-eastVector_[1]*upVector_[2])*cosphi_;
 
 }
 
@@ -111,19 +71,19 @@ MomentumCoriolisSrcNodeSuppAlg::node_execute(
 
 
   // calculate the velocity vector in east-north-up coordinates
-  const double ue = eastVector_[0]*uNp1[0] + eastVector_[1]*uNp1[1] + eastVector_[2]*uNp1[2];
-  const double un = northVector_[0]*uNp1[0] + northVector_[1]*uNp1[1] + northVector_[2]*uNp1[2];
-  const double uu = upVector_[0]*uNp1[0] + upVector_[1]*uNp1[1] + upVector_[2]*uNp1[2];
+  const double ue = cor_.eastVector_[0]*uNp1[0] + cor_.eastVector_[1]*uNp1[1] + cor_.eastVector_[2]*uNp1[2];
+  const double un = cor_.northVector_[0]*uNp1[0] + cor_.northVector_[1]*uNp1[1] + cor_.northVector_[2]*uNp1[2];
+  const double uu = cor_.upVector_[0]*uNp1[0] + cor_.upVector_[1]*uNp1[1] + cor_.upVector_[2]*uNp1[2];
 
   // calculate acceleration in east-north-up coordinates
-  const double ae = corfac_ * (un*sinphi_ - uu*cosphi_);
-  const double an = -corfac_*ue*sinphi_;
-  const double au = corfac_*ue*cosphi_;
+  const double ae = cor_.corfac_ * (un*cor_.sinphi_ - uu*cor_.cosphi_);
+  const double an = -cor_.corfac_*ue*cor_.sinphi_;
+  const double au = cor_.corfac_*ue*cor_.cosphi_;
   
   // calculate acceleration in model x-y-z coordinates
-  const double ax = ae*eastVector_[0] + an*northVector_[0] + au*upVector_[0];
-  const double ay = ae*eastVector_[1] + an*northVector_[1] + au*upVector_[1];
-  const double az = ae*eastVector_[2] + an*northVector_[2] + au*upVector_[2];
+  const double ax = ae*cor_.eastVector_[0] + an*cor_.northVector_[0] + au*cor_.upVector_[0];
+  const double ay = ae*cor_.eastVector_[1] + an*cor_.northVector_[1] + au*cor_.upVector_[1];
+  const double az = ae*cor_.eastVector_[2] + an*cor_.northVector_[2] + au*cor_.upVector_[2];
 
   const double rhoNp1     = *stk::mesh::field_data(*densityNp1_, node );
   const double dualVolume = *stk::mesh::field_data(*dualNodalVolume_, node );
@@ -134,25 +94,13 @@ MomentumCoriolisSrcNodeSuppAlg::node_execute(
   rhs[2] += fac2*az;
 
   // Only the off-diagonal LHS entries are non-zero
-  lhs[1] += fac2*Jxy_;
-  lhs[2] += fac2*Jxz_;
-  lhs[3] -= fac2*Jxy_; // Jyx = - Jxy
-  lhs[5] += fac2*Jyz_;
-  lhs[6] -= fac2*Jxz_; // Jzx = - Jxz
-  lhs[7] -= fac2*Jyz_; // Jzy = - Jyz
+  lhs[1] += fac2*cor_.Jxy_;
+  lhs[2] += fac2*cor_.Jxz_;
+  lhs[3] -= fac2*cor_.Jxy_; // Jyx = - Jxy
+  lhs[5] += fac2*cor_.Jyz_;
+  lhs[6] -= fac2*cor_.Jxz_; // Jzx = - Jxz
+  lhs[7] -= fac2*cor_.Jyz_; // Jzy = - Jyz
 
-}
-
-//--------------------------------------------------------------------------
-//-------- cross_product ----------------------------------------------------
-//--------------------------------------------------------------------------
-void
-MomentumCoriolisSrcNodeSuppAlg::cross_product(
-  std::vector<double> u, std::vector<double> v, std::vector<double> cross)
-{
-  cross[0] =   u[1]*v[2] - u[2]*v[1];
-  cross[1] = -(u[0]*v[2] - u[2]*v[0]);
-  cross[2] =   u[0]*v[1] - u[1]*v[0];
 }
 
 } // namespace nalu


### PR DESCRIPTION
* The CoriolisSrc class contains the setup data and calculations for the
   Coriolis source term.  This prevents code duplication between the Node and
   Element source term algorithms.  Each of these algorithms will now contain
   a CoriolisSrc object with the necessary data.